### PR TITLE
tiny bugfix

### DIFF
--- a/src/ofxTileSaver.h
+++ b/src/ofxTileSaver.h
@@ -114,7 +114,7 @@ public:
 		if(!bGoTiling)
 			return;
 
-		current.grabScreen(border, border, tileWidthNoBorder, tileWidthNoBorder);
+		current.grabScreen(border, border, tileWidthNoBorder, tileHeightNoBorder);
 		if(!bBigImage){
 			current.saveImage(ofToString(currentTile)+".png");
 		} else {


### PR DESCRIPTION
hi benben. I was using this with a vertical aspect ratio screen, and there were gaps when generating a big image.
on close inspection I saw that in the end() method this line

  current.grabScreen(border, border, tileWidthNoBorder, tileWidthNoBorder);

should be

  current.grabScreen(border, border, tileWidthNoBorder, tileHeightNoBorder);

it seems to work now 
thanks for putting this up here!
best,
j
